### PR TITLE
Add Gemini image translation feature

### DIFF
--- a/src/mainwindow.h
+++ b/src/mainwindow.h
@@ -124,6 +124,10 @@ private slots:
     void checkForUpdates();
 #endif
 
+private slots:
+    void onEngineChanged(int index);
+    void onSelectImageButtonClicked();
+
 private:
     void changeEvent(QEvent *event) override;
 
@@ -187,6 +191,8 @@ private:
     bool m_forceSourceAutodetect;
     bool m_forceTranslationAutodetect;
     bool m_listenForContentChanges = false;
+
+    QString m_selectedImagePath; // For Gemini image translation
 };
 
 #endif // MAINWINDOW_H

--- a/src/qonlinetranslator/CMakeLists.txt
+++ b/src/qonlinetranslator/CMakeLists.txt
@@ -41,3 +41,13 @@ if(DOXYGEN_FOUND)
         README.md
     )
 endif()
+
+if(BUILD_TESTING)
+    find_package(Qt5 COMPONENTS Test REQUIRED)
+    add_executable(testqonlinetranslatorgemini tests/testqonlinetranslatorgemini.cpp)
+    # Configure mock script to be in the build directory of the test
+    # This ensures the mock script is available where the test expects it.
+    configure_file(tests/mock_gemini_translate.py ${CMAKE_CURRENT_BINARY_DIR}/mock_gemini_translate.py COPYONLY)
+    target_link_libraries(testqonlinetranslatorgemini PRIVATE Qt5::Test QOnlineTranslator) # Link against QOnlineTranslator library
+    add_test(NAME TestQOnlineTranslatorGemini WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR} COMMAND testqonlinetranslatorgemini)
+endif()

--- a/src/qonlinetranslator/src/gemini_translate.py
+++ b/src/qonlinetranslator/src/gemini_translate.py
@@ -1,0 +1,80 @@
+import os
+import json
+import argparse
+import google.generativeai as genai
+from PIL import Image
+
+# A simple map for language codes to names (can be expanded)
+LANGUAGE_NAME_MAP = {
+    "en": "English",
+    "es": "Spanish",
+    "fr": "French",
+    "de": "German",
+    "ja": "Japanese",
+    "ko": "Korean",
+    "zh": "Chinese",
+    "it": "Italian",
+    "pt": "Portuguese",
+    "ru": "Russian",
+    "ar": "Arabic",
+    "hi": "Hindi",
+}
+
+def get_language_name(code):
+    return LANGUAGE_NAME_MAP.get(code.lower(), code) # Default to code if name not found
+
+def translate_image(api_key, image_path, target_language_code, model_name="gemini-2.0-flash-lite"):
+    try:
+        if not os.path.exists(image_path):
+            return {"error": f"Image file not found: {image_path}"}
+
+        genai.configure(api_key=api_key)
+
+        img = Image.open(image_path)
+
+        target_language_name = get_language_name(target_language_code)
+        prompt = f"Translate the image to {target_language_name}"
+
+        model = genai.GenerativeModel(model_name)
+
+        # Check if the model supports image input.
+        # This is a basic check; actual model capabilities might vary.
+        # For Gemini models that support vision, the content is usually a list of parts.
+        response = model.generate_content([prompt, img])
+
+        if hasattr(response, 'text') and response.text:
+            return {"translation": response.text.strip()}
+        elif hasattr(response, 'parts') and response.parts:
+            # If the response has parts, try to extract text from the first part
+            # This can vary based on the model and SDK version
+            text_parts = [part.text for part in response.parts if hasattr(part, 'text')]
+            if text_parts:
+                return {"translation": " ".join(text_parts).strip()}
+            else:
+                return {"error": "No text found in response parts."}
+        else:
+            # Fallback for unexpected response structure
+            # Log the response for debugging if possible in a real scenario
+            return {"error": "Failed to extract translation from response. The response might be empty or in an unexpected format."}
+
+    except FileNotFoundError:
+        return {"error": f"Image file not found: {image_path}"}
+    except Exception as e:
+        # Broad exception for API errors or other issues
+        # In a production script, more specific error handling would be better
+        # e.g., handling google.api_core.exceptions.GoogleAPIError
+        return {"error": f"An error occurred: {str(e)}"}
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Translate an image using Gemini API.")
+    parser.add_argument("image_path", help="Path to the image file.")
+    parser.add_argument("target_language_code", help="Target language code (e.g., 'es' for Spanish).")
+
+    args = parser.parse_args()
+
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        print(json.dumps({"error": "GEMINI_API_KEY environment variable not set."}))
+    else:
+        result = translate_image(api_key, args.image_path, args.target_language_code)
+        print(json.dumps(result))

--- a/src/qonlinetranslator/src/qonlinetranslator.h
+++ b/src/qonlinetranslator/src/qonlinetranslator.h
@@ -16,6 +16,7 @@
 #include <QUuid>
 #include <QVector>
 
+class QProcess;
 class QStateMachine;
 class QState;
 class QNetworkAccessManager;
@@ -174,7 +175,8 @@ public:
         Yandex,
         Bing,
         LibreTranslate,
-        Lingva
+        Lingva,
+        Gemini
     };
     Q_ENUM(Engine)
 
@@ -214,6 +216,16 @@ public:
      * @param uiLang ui language to use for display
      */
     void translate(const QString &text, Engine engine = Google, Language translationLang = Auto, Language sourceLang = Auto, Language uiLang = Auto);
+    /**
+     * @brief Translate text from an image
+     *
+     * @param imagePath path to the image file
+     * @param engine online engine to use
+     * @param translationLang language to translation
+     * @param sourceLang language of the passed text
+     * @param uiLang ui language to use for display
+     */
+    void translate(const QString &imagePath, Engine engine = Google, Language translationLang = Auto, Language sourceLang = Auto, Language uiLang = Auto);
 
     /**
      * @brief Detect language
@@ -436,6 +448,9 @@ public:
      */
     void setEngineApiKey(Engine engine, QByteArray apiKey);
 
+    // For testing purposes
+    void setGeminiScriptPath(const QString &path);
+
     /**
      * @brief Language name
      *
@@ -525,6 +540,11 @@ private slots:
     void requestLingvaTranslate();
     void parseLingvaTranslate();
 
+    // Gemini
+    void requestGeminiTranslate();
+    void parseGeminiTranslate();
+    void handleGeminiProcessError(QProcess::ProcessError error);
+
 private:
     /*
      * Engines have translation limit, so need to split all text into parts and make request sequentially.
@@ -545,6 +565,8 @@ private:
 
     void buildLingvaStateMachine();
     void buildLingvaDetectStateMachine();
+
+    void buildGeminiStateMachine();
 
     // Helper functions to build nested states
     void buildSplitNetworkRequest(QState *parent, void (QOnlineTranslator::*requestMethod)(), void (QOnlineTranslator::*parseMethod)(), const QString &text, int textLimit);
@@ -615,6 +637,11 @@ private:
     QByteArray m_libreApiKey; // Can be empty, since free instances ignores api_key param
     QString m_libreUrl;
     QString m_lingvaUrl;
+
+    // For Gemini image translation
+    QString m_sourceImagePath;
+    QProcess *m_geminiProcess = nullptr;
+    QString m_geminiScriptPath; // For testing
 
     QMap<QString, QVector<QOption>> m_translationOptions;
     QMap<QString, QVector<QExample>> m_examples;

--- a/src/qonlinetranslator/tests/mock_gemini_translate.py
+++ b/src/qonlinetranslator/tests/mock_gemini_translate.py
@@ -1,0 +1,18 @@
+import sys
+import os
+import json
+
+if __name__ == "__main__":
+    # sys.argv[0] is the script name
+    # sys.argv[1] is expected to be image_path (unused by mock)
+    # sys.argv[2] is expected to be target_language_code (unused by mock)
+
+    mocked_output_env = os.environ.get("MOCKED_GEMINI_OUTPUT")
+
+    if mocked_output_env:
+        # Assume the environment variable contains a valid JSON string
+        print(mocked_output_env)
+    else:
+        # Fallback if the environment variable is not set
+        error_output = {"error": "MOCKED_GEMINI_OUTPUT environment variable not set for mock script"}
+        print(json.dumps(error_output))

--- a/src/qonlinetranslator/tests/testqonlinetranslatorgemini.cpp
+++ b/src/qonlinetranslator/tests/testqonlinetranslatorgemini.cpp
@@ -1,0 +1,122 @@
+#include <QtTest>
+#include <QCoreApplication>
+#include <QSignalSpy>
+#include <QJsonObject>
+#include <QJsonDocument>
+#include <QFile>
+#include <QDir>
+
+// Needs to be relative to where the test executable will be run from (e.g., build directory)
+// or adjust QOnlineTranslator's path finding for tests.
+// For now, assuming it can pick up qonlinetranslator.h via include paths.
+#include "../src/qonlinetranslator.h" // Adjust path if necessary based on CMake setup
+
+class TestQOnlineTranslatorGemini : public QObject
+{
+    Q_OBJECT
+
+public:
+    TestQOnlineTranslatorGemini() = default;
+    ~TestQOnlineTranslatorGemini() = default;
+
+private slots:
+    void initTestCase();
+    void cleanupTestCase();
+    void testTranslateImage_data();
+    void testTranslateImage();
+};
+
+void TestQOnlineTranslatorGemini::initTestCase()
+{
+    // Ensure the mock script is executable if needed by OS, though QProcess usually handles it.
+    // QFile mockScriptFile("mock_gemini_translate.py"); // Assuming it's in the working dir of test
+    // if (mockScriptFile.exists()) {
+    //     mockScriptFile.setPermissions(QFileDevice::ReadOwner | QFileDevice::WriteOwner | QFileDevice::ExeOwner |
+    //                                 QFileDevice::ReadGroup | QFileDevice::ExeGroup |
+    //                                 QFileDevice::ReadOther | QFileDevice::ExeOther);
+    // }
+}
+
+void TestQOnlineTranslatorGemini::cleanupTestCase()
+{
+    // qDeleteAll(m_translatorList); // Example if objects were stored
+}
+
+void TestQOnlineTranslatorGemini::testTranslateImage_data()
+{
+    QTest::addColumn<QString>("imagePath");
+    QTest::addColumn<QOnlineTranslator::Language>("targetLang");
+    QTest::addColumn<QString>("expectedTranslation");
+    QTest::addColumn<QString>("mockedPythonOutput");
+
+    QTest::newRow("french_translation")
+        << "dummy_image.png"
+        << QOnlineTranslator::French
+        << "Bonjour le monde"
+        << QStringLiteral("{\"translation\": \"Bonjour le monde\"}");
+
+    QTest::newRow("error_from_script")
+        << "dummy_image_err.png"
+        << QOnlineTranslator::German
+        << "" // No translation expected
+        << QStringLiteral("{\"error\": \"Script simulated error\"}");
+}
+
+void TestQOnlineTranslatorGemini::testTranslateImage()
+{
+    QFETCH_GLOBAL(QString, imagePath);
+    QFETCH_GLOBAL(QOnlineTranslator::Language, targetLang);
+    QFETCH_GLOBAL(QString, expectedTranslation);
+    QFETCH_GLOBAL(QString, mockedPythonOutput);
+
+    // Create a dummy image file (content doesn't matter for this test)
+    QFile dummyImage(imagePath);
+    if (!dummyImage.open(QIODevice::WriteOnly)) {
+        QFAIL("Failed to create dummy image file for testing.");
+        return;
+    }
+    dummyImage.write("dummy content");
+    dummyImage.close();
+
+    // Set the environment variable for the mock script
+    qputenv("MOCKED_GEMINI_OUTPUT", mockedPythonOutput.toUtf8());
+
+    QOnlineTranslator translator;
+    // The path to the mock script needs to be relative to the test's WORKING_DIRECTORY (CMAKE_CURRENT_BINARY_DIR)
+    translator.setGeminiScriptPath("./mock_gemini_translate.py");
+
+
+    QSignalSpy spy(&translator, &QOnlineTranslator::finished);
+    QSignalSpy errorSpy(&translator, &QOnlineTranslator::errorOccurred); // Assuming such signal exists or use finished + check error()
+
+    translator.translate(imagePath, QOnlineTranslator::Gemini, targetLang, QOnlineTranslator::English, QOnlineTranslator::English);
+
+    // Wait for the finished() signal.
+    // Increased timeout for QProcess to start and finish.
+    if (!spy.wait(10000)) { // 10 seconds timeout
+        // If the main 'finished' signal didn't emit, check if an error was the reason
+        if (translator.error() != QOnlineTranslator::NoError) {
+             // This is an expected path if mockedPythonOutput contains an error
+        } else {
+            QFAIL("Timeout waiting for QOnlineTranslator::finished() signal, or error signal.");
+        }
+    }
+
+    if (mockedPythonOutput.contains("error")) {
+        QVERIFY(translator.error() != QOnlineTranslator::NoError);
+        // The specific error message from the script is checked implicitly by resetData logic
+        // QCOMPARE(translator.errorString(), "Error from Gemini script: Script simulated error"); // This would be more specific
+    } else {
+        QCOMPARE(translator.error(), QOnlineTranslator::NoError);
+        QCOMPARE(translator.translation(), expectedTranslation);
+        QVERIFY(spy.count() >= 1); // finished signal should have been emitted at least once
+    }
+
+    // Cleanup
+    dummyImage.remove();
+    qunsetenv("MOCKED_GEMINI_OUTPUT");
+}
+
+QTEST_MAIN(TestQOnlineTranslatorGemini)
+
+#include "testqonlinetranslatorgemini.moc"


### PR DESCRIPTION
This commit introduces the capability to translate text directly from images using the Gemini 2.0 Flash Lite model.

Key changes include:

- Added "Gemini" as a new translation engine in QOnlineTranslator.
- Implemented the necessary state machine and request/parsing logic for interacting with a Python script that calls the Gemini API.
- The QOnlineTranslator::translate method now has an overload to accept an image file path for translation with the Gemini engine.
- Created a Python script (`src/qonlinetranslator/src/gemini_translate.py`) that uses the `google-generativeai` library to perform image-to-text translation with the "gemini-2.0-flash-lite" model. The script takes an image path and target language, and outputs JSON.
- The main window UI has been updated:
    - "Gemini" is added to the engine selection dropdown.
    - A "Select Image" button appears when Gemini is chosen, allowing you to pick an image file.
    - The translation request logic now handles both text and image inputs for the Gemini engine.
- Added unit tests for the new Gemini image translation functionality in QOnlineTranslator, using a mock Python script to simulate API responses. This involved making the Python script path configurable in QOnlineTranslator for testing purposes.

The Gemini API key is expected to be provided via the `GEMINI_API_KEY` environment variable for the Python script.